### PR TITLE
feat: add hybrid mistweaver pvp rotation

### DIFF
--- a/scripts/AuroraRoutines/Routines/Monk/Mistweaver/Interface.lua
+++ b/scripts/AuroraRoutines/Routines/Monk/Mistweaver/Interface.lua
@@ -1,0 +1,17 @@
+-- Interface for MistweaverHybrid rotation
+-- Provides simple slash commands for toggles
+
+local namespace = "MistweaverHybrid"
+Aurora.State = Aurora.State or {}
+Aurora.State[namespace] = { fistweave = true }
+
+Aurora.Commands:Register("mwhybrid", function(msg)
+    if msg == "fistweave" then
+        local st = Aurora.State[namespace]
+        st.fistweave = not st.fistweave
+        print("[MistweaverHybrid] Fistweave mode: " .. (st.fistweave and "on" or "off"))
+    else
+        print("Usage: /mwhybrid fistweave")
+    end
+end, "Hybrid Mistweaver toggles")
+

--- a/scripts/AuroraRoutines/Routines/Monk/Mistweaver/Interface.lua
+++ b/scripts/AuroraRoutines/Routines/Monk/Mistweaver/Interface.lua
@@ -3,18 +3,15 @@
 
 local namespace = "MistweaverHybrid"
 Aurora.State = Aurora.State or {}
-Aurora.State[namespace] = { fistweave = true }
+Aurora.State[namespace] = Aurora.State[namespace] or { fistweave = true }
+local state = Aurora.State[namespace]
 
--- Commands module may not be available on Aurora by default, so require it if needed
-local Commands = Aurora.Commands or Tinkr:require("commands")
-
-Commands:Register("mwhybrid", "Hybrid Mistweaver toggles", function(msg)
+Aurora:RegisterCommand("mwhybrid", function(msg)
     if msg == "fistweave" then
-        local st = Aurora.State[namespace]
-        st.fistweave = not st.fistweave
-        print("[MistweaverHybrid] Fistweave mode: " .. (st.fistweave and "on" or "off"))
+        state.fistweave = not state.fistweave
+        print("[MistweaverHybrid] Fistweave mode: " .. (state.fistweave and "on" or "off"))
     else
         print("Usage: /mwhybrid fistweave")
     end
-end)
+end, "Hybrid Mistweaver toggles")
 

--- a/scripts/AuroraRoutines/Routines/Monk/Mistweaver/Interface.lua
+++ b/scripts/AuroraRoutines/Routines/Monk/Mistweaver/Interface.lua
@@ -5,7 +5,10 @@ local namespace = "MistweaverHybrid"
 Aurora.State = Aurora.State or {}
 Aurora.State[namespace] = { fistweave = true }
 
-Aurora.Commands:Register("mwhybrid", function(msg)
+-- Commands module may not be available on Aurora by default, so require it if needed
+local Commands = Aurora.Commands or Tinkr:require("commands")
+
+Commands:Register("mwhybrid", "Hybrid Mistweaver toggles", function(msg)
     if msg == "fistweave" then
         local st = Aurora.State[namespace]
         st.fistweave = not st.fistweave
@@ -13,5 +16,5 @@ Aurora.Commands:Register("mwhybrid", function(msg)
     else
         print("Usage: /mwhybrid fistweave")
     end
-end, "Hybrid Mistweaver toggles")
+end)
 

--- a/scripts/AuroraRoutines/Routines/Monk/Mistweaver/Rotation.lua
+++ b/scripts/AuroraRoutines/Routines/Monk/Mistweaver/Rotation.lua
@@ -1,61 +1,87 @@
--- Get a reference to our namespace
+-- Mistweaver Hybrid PvP Rotation
+-- Aurora Framework implementation
+
 local namespace = "MistweaverHybrid"
 
--- Get commonly used units
-local player = Aurora.UnitManager:Get("player")
-local target = Aurora.UnitManager:Get("target")
+-- Units
+local player  = Aurora.UnitManager:Get("player")
+local target  = Aurora.UnitManager:Get("target")
+local ally1   = Aurora.UnitManager:Get("party1")
+local ally2   = Aurora.UnitManager:Get("party2")
 
--- Get the spellbook
-local spells = Aurora.SpellHandler.Spellbooks.monk["2"][namespace].spells
-local auras = Aurora.SpellHandler.Spellbooks.monk["2"][namespace].auras
-local talents = Aurora.SpellHandler.Spellbooks.monk["2"][namespace].talents
+-- Spellbook shortcuts
+local book   = Aurora.SpellHandler.Spellbooks.monk["2"][namespace]
+local spells = book.spells
+local auras  = book.auras
+local state  = Aurora.State[namespace]
 
--- Define the hybrid rotation logic
+-- Helper: return lowest health ally
+local function lowestAlly()
+    local units = {player, ally1, ally2}
+    local lowest, hp = nil, 101
+    for _, u in ipairs(units) do
+        if u and u.exists and not u.dead and u.health.percent < hp then
+            lowest, hp = u, u.health.percent
+        end
+    end
+    return lowest
+end
+
+-- Combat logic
 local function HybridRotation()
-    -- Defensive and Healing
-    -- Use Life Cocoon on player if health is very low
-    if player.health.percent < 20 and spells.LifeCocoon:execute(player) then return true end
+    local ally = lowestAlly()
 
-    -- Use Fortifying Brew if health is low
-    if player.health.percent < 40 and spells.FortifyingBrew:execute() then return true end
+    if ally then
+        -- Emergency tools
+        if ally.health.percent < 25 and spells.LifeCocoon:execute(ally) then return true end
+        if ally.health.percent < 35 and spells.Revival:execute() then return true end
+        if ally == player and player.health.percent < 40 and spells.FortifyingBrew:execute() then return true end
+        if ally == player and player.health.percent < 50 and spells.DiffuseMagic:execute() then return true end
 
-    -- Keep Renewing Mist up on the player
-    if not player:aura(auras.RenewingMistHoT) and spells.RenewingMist:execute(player) then return true end
+        -- Core healing
+        if not ally:aura(auras.RenewingMistHoT) and spells.RenewingMist:execute(ally) then return true end
+        if ally.health.percent < 60 and spells.EnvelopingMist:execute(ally) then return true end
+        if ally.health.percent < 70 then
+            if spells.ThunderFocusTea:ready() and spells.ThunderFocusTea:execute(player) then return true end
+            if spells.Vivify:execute(ally) then return true end
+        end
+    end
 
-    -- Use Vivify for moderate healing
-    if player.health.percent < 70 and spells.Vivify:execute(player) then return true end
+    -- Self stabilisation
+    if player.health.percent < 80 and spells.ExpelHarm:execute(player) then return true end
 
-    -- Fistweaving DPS Rotation
-    -- Use Rising Sun Kick on cooldown
-    if spells.RisingSunKick:execute(target) then return true end
-
-    -- Use Blackout Kick to reset Rising Sun Kick
-    if spells.BlackoutKick:execute(target) then return true end
-
-    -- Use Tiger Palm to generate Chi and buff Blackout Kick
-    if spells.TigerPalm:execute(target) then return true end
-
-    -- Use Crackling Jade Lightning as a filler
-    if spells.CracklingJadeLightning:execute(target) then return true end
+    -- Fistweaving block when no one is in danger
+    if state.fistweave and (not ally or ally.health.percent > 80) and target.exists and target.enemy then
+        if spells.RisingSunKick:execute(target) then return true end
+        if player:aura(auras.TeachingsOfTheMonastery) == 3 and spells.BlackoutKick:execute(target) then return true end
+        if spells.BlackoutKick:execute(target) then return true end
+        if spells.TigerPalm:execute(target) then return true end
+        if spells.CracklingJadeLightning:execute(target) then return true end
+    end
 
     return false
 end
 
--- Define out of combat actions
+-- Out of combat utility
 local function OutOfCombat()
-    -- Placeholder for out-of-combat logic
+    -- Place statue and maintain renewing mist
+    if spells.JadeSerpentStatue:ready() then
+        spells.JadeSerpentStatue:execute(player)
+    end
+    for _, u in ipairs({player, ally1, ally2}) do
+        if u and u.exists and not u.dead and not u:aura(auras.RenewingMistHoT) then
+            spells.RenewingMist:execute(u)
+        end
+    end
     return false
 end
 
--- Register the routine with Aurora
 Aurora:RegisterRoutine(function()
-    -- Skip if player is dead, casting, or in a vehicle
     if player.dead or player:casting() or player:inVehicle() then return end
-
-    -- Run appropriate function based on combat state
-    if player.combat and target.exists and target.enemy then
+    if player.combat then
         HybridRotation()
     else
         OutOfCombat()
     end
 end, "MONK", 2, namespace)
+

--- a/scripts/AuroraRoutines/Routines/Monk/Mistweaver/Spellbook.lua
+++ b/scripts/AuroraRoutines/Routines/Monk/Mistweaver/Spellbook.lua
@@ -13,6 +13,8 @@ Aurora.SpellHandler.PopulateSpellbook({
     DiffuseMagic        = NewSpell(122783),
     ExpelHarm           = NewSpell(322101),
     ManaTea             = NewSpell(197908),
+    SheilunsGift        = NewSpell(399491),
+    JadeSerpentStatue   = NewSpell(115313),
 
     -- Schaden (Fistweaving)
     TigerPalm           = NewSpell(100780),


### PR DESCRIPTION
## Summary
- implement hybrid Mistweaver PvP rotation with healing priorities and fistweave DPS
- expose slash command to toggle fistweaving mode
- expand spellbook with Sheilun's Gift and Jade Serpent Statue

## Testing
- `luac -p scripts/AuroraRoutines/Main.lua scripts/AuroraRoutines/Routines/Monk/Mistweaver/Spellbook.lua scripts/AuroraRoutines/Routines/Monk/Mistweaver/Interface.lua scripts/AuroraRoutines/Routines/Monk/Mistweaver/Rotation.lua`


------
https://chatgpt.com/codex/tasks/task_e_6890e7deeaf0832785f5122e137ba111